### PR TITLE
Revamp AIDeployHelper.

### DIFF
--- a/OpenRA.Mods.yupgi_alert/Traits/AIDeployHelper.cs
+++ b/OpenRA.Mods.yupgi_alert/Traits/AIDeployHelper.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -10,102 +10,114 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using OpenRA.Activities;
-using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
-using OpenRA.Mods.AS.Traits;
 
-namespace OpenRA.Mods.Common.Traits
+namespace OpenRA.Mods.yupgi_alert.Traits
 {
 	[Flags]
-	public enum DeployType
+	public enum DeployTriggers
 	{
 		None = 0,
-		Attacked = 1,
-		Attack = 2,
-		Damage = 4,
+		Attack = 1,
+		Damage = 2,
+		Heal = 4
 	}
 
-	[Desc("This unit can deploy automatically, when AI is the owner.")]
-	public class AIDeployHelperInfo: ITraitInfo
+	[Desc("If this unit is owned by an AI, issue a deploy order automatically.")]
+	public class AIDeployHelperInfo : ITraitInfo
 	{
-		[Desc("Events leading to the actor getting uncloaked. Possible values are: None, Attacked, Attack, Damage.")]
-		public readonly DeployType DeployOn = DeployType.None;
+		[Desc("Events leading to the actor getting uncloaked. Possible values are: None, Attack, Damage, Heal.")]
+		public readonly DeployTriggers DeployTrigger = DeployTriggers.Attack | DeployTriggers.Damage;
+
+		[Desc("Chance of deploying when the trigger activates.")]
+		public readonly int DeployChance = 100;
+
+		[Desc("Delay between two successful deploy orders.")]
+		public readonly int DeployTicks = 2500;
+
+		[Desc("Delay to wait for the actor to undeploy (if capable to) after a successful deploy.")]
 		public readonly int UndeployTicks = 450;
 
 		public object Create(ActorInitializer init) { return new AIDeployHelper(this); }
 	}
 
-	public class AIDeployHelper : INotifyDamageStateChanged, INotifyAttack, ITick
+	public class AIDeployHelper : INotifyAttack, ITick, INotifyDamage, INotifyCreated, ISync
 	{
-		AIDeployHelperInfo Info;
-		[Sync] int undeploy_ticks;
+		readonly AIDeployHelperInfo info;
+
+		[Sync] int undeployTicks, deployTicks;
+		bool undeployable;
 
 		public AIDeployHelper(AIDeployHelperInfo info)
 		{
-			Info = info;
+			this.info = info;
 		}
 
-		void Deploy(Actor self)
+		void INotifyCreated.Created(Actor self)
 		{
-			undeploy_ticks = Info.UndeployTicks;
+			undeployable = self.Info.HasTraitInfo<GrantConditionOnDeployInfo>();
+		}
 
-			if (!self.Owner.IsBot)
+		void TryDeploy(Actor self)
+		{
+			if (deployTicks > 0)
 				return;
 
-			// Issue deploy order to self.
-			self.CancelActivity();
+			if (self.World.SharedRandom.Next(100) > info.DeployChance)
+				return;
 
-			var gc = self.TraitOrDefault<GrantConditionOnDeploy>();
-			if (gc != null)
-				gc.AIDeploy();
+			self.World.IssueOrder(new Order("DeployTransform", self, false));
+			self.World.IssueOrder(new Order("Unload", self, false));
+			self.World.IssueOrder(new Order("Detonate", self, false));
+			self.World.IssueOrder(new Order("GrantConditionOnDeploy", self, false));
 
-			var gct = self.TraitOrDefault<GrantTimedConditionOnDeploy>();
-			if (gct != null)
-				gct.AIDeploy();
+			if (undeployable)
+				undeployTicks = info.UndeployTicks;
+
+			deployTicks = info.DeployTicks;
 		}
 
 		void Undeploy(Actor self)
 		{
-			if (!self.Owner.IsBot)
-				return;
-
-			self.CancelActivity();
-
-			// Issue undeploy order to self.
-			var gc = self.TraitOrDefault<GrantConditionOnDeploy>();
-			if (gc != null)
-			{
-				gc.AIUndeploy();
-			}
+			self.World.IssueOrder(new Order("GrantConditionOnDeploy", self, false));
 		}
 
 		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
 		{
-			if (Info.DeployOn.HasFlag(DeployType.Attack))
-				Deploy(self);
+			if (!self.Owner.IsBot)
+				return;
+
+			if (info.DeployTrigger.HasFlag(DeployTriggers.Attack))
+				TryDeploy(self);
 		}
-		
+
 		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
 
 		void ITick.Tick(Actor self)
 		{
-			if (--undeploy_ticks < 0)
+			if (!self.Owner.IsBot)
+				return;
+
+			if (undeployable && --undeployTicks < 0)
 			{
-				undeploy_ticks = Info.UndeployTicks;
 				Undeploy(self);
 			}
+
+			if (deployTicks > 0)
+				deployTicks--;
 		}
 
-		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
-			if (Info.DeployOn.HasFlag(DeployType.Damage))
-			{
-				Deploy(self);
-			}
+			if (!self.Owner.IsBot)
+				return;
+
+			if (e.Damage.Value > 0 && info.DeployTrigger.HasFlag(DeployTriggers.Damage))
+				TryDeploy(self);
+
+			if (e.Damage.Value < 0 && info.DeployTrigger.HasFlag(DeployTriggers.Heal))
+				TryDeploy(self);
 		}
 	}
 }

--- a/OpenRA.Mods.yupgi_alert/Traits/Conditions/GrantTimedConditionOnDeploy.cs
+++ b/OpenRA.Mods.yupgi_alert/Traits/Conditions/GrantTimedConditionOnDeploy.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2015- OpenRA.Mods.AS Developers (see AUTHORS)
  * This file is a part of a third-party plugin for OpenRA, which is
@@ -169,12 +169,6 @@ namespace OpenRA.Mods.AS.Traits
 					deployingToken = manager.GrantCondition(self, info.DeployingCondition);
 				body.Value.PlayCustomAnimation(self, info.DeployAnimation, OnDeployCompleted);
 			}
-		}
-
-		public void AIDeploy()
-		{
-			// Just an interface for my AI Deploy Helper.
-			Deploy();
 		}
 
 		void OnDeployCompleted()


### PR DESCRIPTION
Instead of the hacky "interfaces" it called before, it now issues the actual orders to the unit. Also added unload and detonation as deploy results.

Also removed nonexistant Attacked entry, because that was unused, Damaged used DamageStateChanged which is wrong - although if you need that explicitly, I guess I can restore that.

Related to https://github.com/forcecore/OpenRA/pull/1. You probably want to take both at the same time.